### PR TITLE
hack on input_source

### DIFF
--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -36,6 +36,11 @@ impl std::ops::DerefMut for TransactionRecordsById {
         &mut self.0
     }
 }
+impl Default for TransactionRecordsById {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl TransactionRecordsById {
     // initializers
 


### PR DESCRIPTION
add default because: https://rust-lang.github.io/rust-clippy/master/i…ndex.html#/new_without_default